### PR TITLE
Adds selectRouterState option

### DIFF
--- a/lib/redux-first-history.js
+++ b/lib/redux-first-history.js
@@ -97,9 +97,15 @@ var createReduxHistoryContext = function createReduxHistoryContext(_ref2) {
       _ref2$reduxTravelling = _ref2.reduxTravelling,
       reduxTravelling = _ref2$reduxTravelling === undefined ? false : _ref2$reduxTravelling,
       _ref2$showHistoryActi = _ref2.showHistoryAction,
-      showHistoryAction = _ref2$showHistoryActi === undefined ? false : _ref2$showHistoryActi;
+      showHistoryAction = _ref2$showHistoryActi === undefined ? false : _ref2$showHistoryActi,
+      _ref2$selectRouterSta = _ref2.selectRouterState,
+      selectRouterState = _ref2$selectRouterSta === undefined ? null : _ref2$selectRouterSta;
 
   /**********************************************  REDUX REDUCER ******************************************************/
+  var getRouterState = function getRouterState(store) {
+    var state = store.getState();
+    return selectRouterState ? selectRouterState(state) : state[routerReducerKey];
+  };
 
   var locationChangeAction = function locationChangeAction(location, action) {
     return {
@@ -167,11 +173,15 @@ var createReduxHistoryContext = function createReduxHistoryContext(_ref2) {
     };
 
     return store.subscribe(function () {
-      var sLoc = store.getState()[routerReducerKey].location;
+      var sLoc = getRouterState(store).location;
       var hLoc = history.location;
       if (sLoc && hLoc && !locationEqual(sLoc, hLoc)) {
         isReduxTravelling = true;
-        history.push({ pathname: sLoc.pathname, search: sLoc.search, hash: sLoc.hash });
+        history.push({
+          pathname: sLoc.pathname,
+          search: sLoc.search,
+          hash: sLoc.hash
+        });
       }
     });
   };
@@ -193,16 +203,14 @@ var createReduxHistoryContext = function createReduxHistoryContext(_ref2) {
       if (isReduxTravelling) {
         isReduxTravelling = false;
         //notify registered callback travelling
-        var _state = store.getState();
         registeredCallback.forEach(function (c) {
-          return c(_state[routerReducerKey].location, _state[routerReducerKey].action);
+          return c(getRouterState(store).location, getRouterState(store).action);
         });
         return;
       }
       store.dispatch(locationChangeAction(location, action));
-      var state = store.getState();
       registeredCallback.forEach(function (c) {
-        return c(state[routerReducerKey].location, state[routerReducerKey].action);
+        return c(getRouterState(store).location, getRouterState(store).action);
       });
     });
 
@@ -240,14 +248,14 @@ var createReduxHistoryContext = function createReduxHistoryContext(_ref2) {
     //location tunnel
     Object.defineProperty(reduxFirstHistory, 'location', {
       get: function get() {
-        return store.getState()[routerReducerKey].location;
+        return getRouterState(store).location;
       }
     });
 
     //action tunnel
     Object.defineProperty(reduxFirstHistory, 'action', {
       get: function get() {
-        return store.getState()[routerReducerKey].action;
+        return getRouterState(store).action;
       }
     });
 


### PR DESCRIPTION
Adds support for #6. This would allow us to support any state shape, if that is desired.

Generally, the update replaces all instances of `store.getState()[routerReducerKey]` with `getRouterState(store)`. That function will either use the `selectRouterState` option if it exists or fall back to the current way of looking up the state based on `routerReducerKey`.

I noticed from the diff that many of changes came from prettier. I can undo those if the changes aren't desired.