### PR TITLE
Strongly type action creators

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -19,9 +19,9 @@ export const locationChangeAction = (location: Location, action: Action) => ({
    payload: { location, action },
 });
 
-function updateLocation(method: HistoryMethods) {
+function updateLocation<T extends HistoryMethods>(method: T) {
    // @ts-ignore
-   return (...args: Parameters<History[HistoryMethods]>): ReduxAction => ({
+   return (...args: Parameters<History[T]>): ReduxAction => ({
       type: CALL_HISTORY_METHOD,
       payload: { method, args },
    });


### PR DESCRIPTION
Using `HistoryMethods` as the type tries to find the overlap between all the types which resolves to `never`. Making the method generic allows TypeScript to propagate forward the correct arguments