### PR TITLE
Add RouterActions type

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -35,3 +35,13 @@ export const goBack: () => ReduxAction = updateLocation('goBack');
 export const goForward: () => ReduxAction = updateLocation('goForward');
 export const back: () => ReduxAction = updateLocation('back');
 export const forward: () => ReduxAction = updateLocation('forward');
+
+export type RouterActions = 
+   ReturnType<typeof push> | 
+   ReturnType<typeof replace> |
+   ReturnType<typeof go> | 
+   ReturnType<typeof goBack> | 
+   ReturnType<typeof goForward> | 
+   ReturnType<typeof locationChangeAction> | 
+   ReturnType<typeof back> |
+   ReturnType<typeof forward>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export { reachify } from './reachify';
 export { createReduxHistoryContext } from './create';
 export type { IHistoryContext, IHistoryContextOptions } from './create';
 export type { RouterState } from './reducer';
+export type { RouterActions } from './actions';


### PR DESCRIPTION
See issue #63. With redux-observable it is a pattern to have all actions as a union type, it would be nice if this library also exports an union of all possible action types. This would not require any new dependency as it is pure TypeScript.

There is no test added as it is only a type.