### PR TITLE
patch callbackRegister in create.ts so that when app remount, it still h…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "redux-first-history",
-   "version": "5.1.1",
+   "version": "5.1.2",
    "description": "Redux First History - Redux history binding support react-router - @reach/router - wouter",
    "main": "build/es5/index.js",
    "module": "build/es6/index.js",

--- a/src/create.ts
+++ b/src/create.ts
@@ -32,6 +32,7 @@ export interface IHistoryContext {
    routerReducer: Reducer<RouterState>;
 }
 
+let registeredCallback: unknown[] = [];
 export const createReduxHistoryContext = ({
    history,
    routerReducerKey = 'router',
@@ -51,7 +52,7 @@ export const createReduxHistoryContext = ({
 
    if (typeof batch !== 'function') {
       batch = fn => {
-         fn();
+         fn.bind({ registeredCallback })();
       };
    }
 
@@ -86,8 +87,6 @@ export const createReduxHistoryContext = ({
    /** ******************************************  REDUX FIRST HISTORY   *********************************************** */
 
    const createReduxHistory = (store: Store): History & { listenObject: boolean } => {
-      let registeredCallback: unknown[] = [];
-
       // init location store
       store.dispatch(locationChangeAction(history.location, history.action));
 


### PR DESCRIPTION
…as a unique reference
I'm submitting this PR following a bug encountered on my current project.
Symptomes where the following : after remounting the react app following an unmount, the LocationRouter couldn't successfully register the setState has a listener of history.
The diagnostic is that after recreating the history object with facotry function, the referenced callbackRegister is no longer the one referenced in the batch function context. Moving it's declaration in the module main contexte and binding it's value to the batch function solved the issue