### PR TITLE
Keep AsyncThunkAction, in @reduxjs/toolkit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ export const store = configureStore({
   reducer: combineReducers({
     router: routerReducer
   }),
-  middleware: [routerMiddleware]
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(routerMiddleware),
 });
 
 export const history = createReduxHistory(store);


### PR DESCRIPTION
Hello, it seems that using the array syntax for middleware is not recommended according to the [redux toolkit documentation](https://redux-toolkit.js.org/api/getDefaultMiddleware#intended-usage). 
Without `(getDefaultMiddleware) => getDefaultMiddleware().concat(logger)` `dispatch` seems to be missing the correct type (`AnyAction` instead of `ThunkAction`), when scaffolding a CRA project with the official redux-toolkit template.

Incorrect (`[routerMiddleware]`)

<img width="816" alt="Screenshot 2023-01-20 at 21 22 55" src="https://user-images.githubusercontent.com/6861911/213808148-cf36237e-7d07-4e97-9b54-bf1bc371c0c5.png">


Correct (`(getDefaultMiddleware) => getDefaultMiddleware().concat(routerMiddleware)`)

<img width="996" alt="Screenshot 2023-01-20 at 21 23 23" src="https://user-images.githubusercontent.com/6861911/213808179-61ea0214-b27a-4541-bf62-89b6c32e958a.png">

Cheers

