### PR TITLE
add generics for LocationState of `push`, `replace`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "redux-first-history",
-   "version": "5.1.1",
+   "version": "5.1.2",
    "description": "Redux First History - Redux history binding support react-router - @reach/router - wouter",
    "main": "build/es5/index.js",
    "module": "build/es6/index.js",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -36,12 +36,16 @@ function updateLocation<T extends HistoryMethods>(method: T) {
    });
 }
 
-export const push: (
-   ...args: Parameters<History['push']>
-) => CallHistoryMethodAction<Parameters<History['push']>> = updateLocation('push');
-export const replace: (
-   ...args: Parameters<History['replace']>
-) => CallHistoryMethodAction<Parameters<History['replace']>> = updateLocation('replace');
+export function push<S = History.LocationState>(
+   ...args: Parameters<History<S>['push']>
+): CallHistoryMethodAction<Parameters<History['push']>> {
+   return updateLocation('push')(...args);
+}
+export function replace<S = History.LocationState>(
+   ...args: Parameters<History<S>['replace']>
+): CallHistoryMethodAction<Parameters<History['replace']>> {
+   return updateLocation('replace')(...args);
+}
 export const go: (
    ...args: Parameters<History['go']>
 ) => CallHistoryMethodAction<Parameters<History['go']>> = updateLocation('go');


### PR DESCRIPTION
First of all, thank you for maintaining `redux-first-history`.

### Why

I was migrating from `connect-react-rotuer`. and overall process was fine but, encounter this

<img width="867" alt="image" src="https://github.com/salvoravida/redux-first-history/assets/42806386/fd4dfc9c-93ec-45a9-92a6-92f095b76d81">

So, I'd tried to augment the type as below, but the push is exposed as `const`. which turned out to be no augmentation allowed

```ts
// redux-first-history.d.ts
declare module 'redux-first-history' {
  function push<S = History.LocationState>(
    ...args: Parameters<History<S>['push']>
  ): CallHistoryMethodAction<Parameters<History<S>['push']>>;
}
```

### What

make LocationState injectable, `type variable`.

<img width="825" alt="image" src="https://github.com/salvoravida/redux-first-history/assets/42806386/ee808af5-1f87-4762-af17-b2009e215c63">
